### PR TITLE
Fix selecting current word

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -132,10 +132,10 @@ endfunction
 nmap <F1> :make<CR>
 
 " F2 -> Uppercase the current word.
-nnoremap <F2> bvwU<Esc>
+nnoremap <F2> viwU
 
 " F3 -> Lowecase the current word.
-nnoremap <F3> bvwu<Esc>
+nnoremap <F3> viwu
 
 " F4 -> Call vim-autopep8.
 autocmd FileType python noremap <buffer><F4> :call Autopep8()<CR>


### PR DESCRIPTION
`bvw` is a bad idea. It does different things based on the position of the cursor in the word. If the cursor is on the first character it will jump on the word before, otherwise it uppercases the current word and the first letter of the next word. It can be changed to `viw` to not affect the next word, and I don't think you need the `<Esc>`.